### PR TITLE
Support diagnostic error messages on field decoding failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added comprehensive test coverage for all function-related functionality
   - Maintained 100% code coverage across the project
 
+- **Invalid Field Value Error Diagnostics**: An error diagnostic is now emitted when an invalid field value
+    is supplied (like invalid JSON to a json field). Previously, the plugin would crash.
+
 ### Changed
 
 - Updated `GetFunctions` test to reflect the new implementation (no longer returns "not implemented" warning)

--- a/tf/blocks.py
+++ b/tf/blocks.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from tf.schema import Block, NestedBlock, NestMode
+from tf.utils import Diagnostics
 
 # class SingleNestedBlock(NestedBlock):
 #     def __init__(self, type_name: str, block: Block, required: Optional[bool] = False):
@@ -32,7 +33,11 @@ class SetNestedBlock(NestedBlock):
     def decode(self, value: Any) -> Any:
         from tf.provider import _decode_state
 
-        return [_decode_state(self._amap(), self._bmap(), v)[1] for v in value]
+        # TODO: This kind of sucks. Really we should probably take a diagnostics object,
+        # but consistency would require us to change all other .decode methods to do that.
+        # Maybe that's not such a bad idea?
+        diags = Diagnostics()
+        return [_decode_state(diags, self._amap(), self._bmap(), v)[1] for v in value]
 
     def semantically_equal(self, a_decoded, b_decoded) -> bool:
         # Since this is a set, we turn the block into a tuple

--- a/tf/tests/test_provider.py
+++ b/tf/tests/test_provider.py
@@ -1365,7 +1365,7 @@ class ReadResourceTest(ProviderTestBase):
         resp = servicer.ReadResource(
             pb.ReadResource.Request(
                 type_name="test_json",
-                current_state=to_dynamic_value({"json": "[1,]"}),
+                current_state=to_dynamic_value({"json": "not valid json"}),
                 private=b"",
                 provider_meta={},
             ),
@@ -1378,7 +1378,7 @@ class ReadResourceTest(ProviderTestBase):
                     pb.Diagnostic(
                         severity=pb.Diagnostic.ERROR,
                         summary="Failed to decode field 'json'",
-                        detail="Error decoding field 'json': Error parsing JSON: Expecting value: line 1 column 4 (char 3)",
+                        detail="Error decoding field 'json': Error parsing JSON: Expecting value: line 1 column 1 (char 0)",
                         attribute=pb.AttributePath(steps=[pb.AttributePath.Step(attribute_name="json")]),
                     )
                 ],

--- a/tf/tests/test_types.py
+++ b/tf/tests/test_types.py
@@ -53,9 +53,9 @@ class TypesTest(TestCase):
     def test_json_decode_error(self):
         json = types.NormalizedJson()
         with self.assertRaises(ValueError) as e:
-            json.decode("[1,2,3,]")
+            json.decode("not valid json")
 
-        self.assertEqual(str(e.exception), "Error parsing JSON: Expecting value: line 1 column 8 (char 7)")
+        self.assertEqual(str(e.exception), "Error parsing JSON: Expecting value: line 1 column 1 (char 0)")
 
     def test_list_encode(self):
         list_type = types.List(types.Number())

--- a/tf/tests/test_types.py
+++ b/tf/tests/test_types.py
@@ -50,6 +50,13 @@ class TypesTest(TestCase):
             json.encode({"key2": "value2", "key1": "value1"}),
         )
 
+    def test_json_decode_error(self):
+        json = types.NormalizedJson()
+        with self.assertRaises(ValueError) as e:
+            json.decode("[1,2,3,]")
+
+        self.assertEqual(str(e.exception), "Error parsing JSON: Expecting value: line 1 column 8 (char 7)")
+
     def test_list_encode(self):
         list_type = types.List(types.Number())
 

--- a/tf/types.py
+++ b/tf/types.py
@@ -91,7 +91,10 @@ class NormalizedJson(String):
         return json.dumps(value, sort_keys=True) if value not in (None, Unknown) else value
 
     def decode(self, value: Any) -> Any:
-        return json.loads(value) if value not in (None, Unknown) else value
+        try:
+            return json.loads(value) if value not in (None, Unknown) else value
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error parsing JSON: {e}") from e
 
     def semantically_equal(self, a_decoded, b_decoded) -> bool:
         # This is hilariously inefficient but meh


### PR DESCRIPTION
Prior to this change, submitting invalid JSON in a resource's json field would lead to a plugin crash. Now we emit an error diagnostic pointing to the invalid field.