### PR TITLE
Allow Schemas/Blocks to specify description(kind) and deprecated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Descriptions and Deprecation Fields for Schemas and Blocks**:
+  - Added `description`, `description_kind`, and `deprecated` fields to Schema and Block. This allows resource, data sources, and providers to specify these fields for documentation.
+
 ## 1.1.0
 
 ### Added

--- a/tf/schema.py
+++ b/tf/schema.py
@@ -85,7 +85,7 @@ class Attribute:
 
 class Schema:
     """
-    A schema is a description of the data model for a resource type.
+    A schema is a description of the data model for a resource/data source/provider.
 
     :param attributes: List of attributes
     :param version: Version of the schema
@@ -111,28 +111,55 @@ class Schema:
         attributes: Optional[list[Attribute]] = None,
         version: Optional[int] = None,
         block_types: Optional[list["NestedBlock"]] = None,
+        description: Optional[str] = None,
+        description_kind: Optional[TextFormat] = None,
+        deprecated: Optional[bool] = None,
     ):
         self.attributes = attributes or []
         self.version: Optional[int] = version
         self.block_types = block_types or []
+        self.description = description
+        self.description_kind = description_kind
+        self.deprecated = deprecated
 
     def to_pb(self) -> pb.Schema:
         more = {"version": self.version} if self.version is not None else {}
 
         return pb.Schema(
-            block=Block(attributes=self.attributes, block_types=self.block_types).to_pb(),
+            block=Block(
+                attributes=self.attributes,
+                block_types=self.block_types,
+                description=self.description,
+                description_kind=self.description_kind,
+                deprecated=self.deprecated,
+            ).to_pb(),
             **more,
         )
 
 
 class Block:
-    def __init__(self, attributes: Optional[list[Attribute]] = None, block_types: Optional[list["NestedBlock"]] = None):
+    def __init__(
+        self,
+        attributes: Optional[list[Attribute]] = None,
+        block_types: Optional[list["NestedBlock"]] = None,
+        description: Optional[str] = None,
+        description_kind: Optional[TextFormat] = None,
+        deprecated: Optional[bool] = None,
+    ):
         self.attributes = attributes or []
         self.block_types = block_types or []
+        self.description = description
+        self.description_kind = description_kind
+        self.deprecated = deprecated
 
     def to_pb(self) -> pb.Schema.Block:
         more = {
             "block_types": [nb.to_pb() for nb in self.block_types] or None,
+            "description": self.description,
+            "description_kind": _desc_format_map[self.description_kind]
+            if self.description_kind
+            else (_desc_format_map[TextFormat.Markdown] if self.description else None),
+            "deprecated": self.deprecated,
         }
 
         not_none = {k: v for k, v in more.items() if v is not None}

--- a/tf/tests/test_schema.py
+++ b/tf/tests/test_schema.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from tf.gen import tfplugin_pb2 as pb
-from tf.schema import Schema
+from tf.schema import Schema, TextFormat
 
 
 class SchemaTest(TestCase):
@@ -19,5 +19,47 @@ class SchemaTest(TestCase):
             pb.Schema(
                 version=9,
                 block=pb.Schema.Block(attributes=[]),
+            ),
+        )
+
+    def test_encode_description(self):
+        schema = Schema(
+            description="This is a test schema",
+        )
+        self.assertEqual(
+            schema.to_pb(),
+            pb.Schema(
+                block=pb.Schema.Block(
+                    description="This is a test schema",
+                    description_kind="MARKDOWN",
+                ),
+            ),
+        )
+
+    def test_encode_description_plain(self):
+        schema = Schema(
+            description="This is a test schema",
+            description_kind=TextFormat.Plain,
+        )
+        self.assertEqual(
+            schema.to_pb(),
+            pb.Schema(
+                block=pb.Schema.Block(
+                    description="This is a test schema",
+                    description_kind="PLAIN",
+                ),
+            ),
+        )
+
+    def test_encode_deprecated(self):
+        schema = Schema(
+            deprecated=True,
+        )
+        self.assertEqual(
+            schema.to_pb(),
+            pb.Schema(
+                block=pb.Schema.Block(
+                    deprecated=True,
+                ),
             ),
         )


### PR DESCRIPTION
These fields are really only useful if you want to generate documentation from your schemas.