### PR TITLE
Fix Set Encoding + Field Names on Encoding Crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Set Crashes**:
   - Fixed crashes when using `Set` types without either provided or default values.
         This fixes the general case for complex types with custom semantic equality functions (only `Set` currently).
-
-### Fixed
-
-- Fixed the gRPC server self-signed certificate being generated with `not_valid_before` in the future
-  - This was caused by generating a `datetime` in the local timezone, but `x509` treating it as UTC
+- **Certificate Generation Failure**:
+  - Fixed certificate generation failure on systems with a positive UTC offset (e.g. UTC+2).
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added comprehensive end-to-end tests against OpenTofu. This ensures that providers, resources, and data sources work correctly against the real OpenTofu CLI.
 - **Tutorial**:
   - Added a tutorial to the documentation to help new users get started with writing a provider using `tf`.
+- **Field Names for Encoding Errors**:
+  - Field names are now printed in rare cases where field values first pass validation/decoding,
+        but later catastrophically fail to encode or semantically compare.
+        These cases are generally bugs in `tf` itself, but the field names help identify the problematic fields.
+
+### Fixed
+- **Set Crashes**:
+  - Fixed crashes when using `Set` types without either provided or default values.
+        This fixes the general case for complex types with custom semantic equality functions (only `Set` currently).
 
 ### Fixed
 

--- a/e2e/mathprovider/mathprovider/test_provider.py
+++ b/e2e/mathprovider/mathprovider/test_provider.py
@@ -89,3 +89,21 @@ class DataSourceTest(ProviderTest):
                 "The 'divisor' attribute cannot be zero.",
             ],
         )
+
+    def test_apply_for_each(self):
+        result = self.tf_apply(
+            """\
+            data "math_div" "test" {
+                for_each = toset(["2", "5", "10"])
+                
+                dividend = 20
+                divisor  = tonumber(each.value)
+            }
+
+            output "the_sum" {
+                value = sum([for d in data.math_div.test : d.quotient])
+            }
+            """,
+            expect_error=False,
+        )
+        self.assertIn("the_sum = 16", result.stdout)


### PR DESCRIPTION
This fixes a bug where set-typed fields without default or specified values would crash on creation. This is because of an encoding bug: we passed in Unknown to the custom `semantically_equal` function implemented by Set. It was not expecting Unknown.

I went back and forth a couple of times on whether `semantically_equal` should be Unknown-aware or not. I am still not really sure. I ended up obviating the need to make a decision on that because the specific case that caused this had a broader solution: If the planned value was Unknown then we should just accept whatever the new value is. It can't be worse than Unknown.

I also added exception enrichment if this happens again and the provider framework catastrophically crashes. Now it will tell you specifically what field led to the exception.